### PR TITLE
Resolve syntax error in example database import

### DIFF
--- a/sample_config/database-layout-update-001.sql
+++ b/sample_config/database-layout-update-001.sql
@@ -84,11 +84,10 @@ SELECT DISTINCT
     c.end_date,
     c.prio,
     c.shutdown_vm
-FROM
+FROM (
     sysinfo_to_thinclient_mapping s
-    LEFT JOIN (
-        current_thinclient_to_vm_mapping c ON (((s.thinclient)::text = (c.thinclient)::text))
-    )
+    LEFT JOIN current_thinclient_to_vm_mapping c ON (((s.thinclient)::text = (c.thinclient)::text))
+)
 ORDER BY
     c.prio DESC,
     c.start_date,

--- a/sample_config/database-layout.sql
+++ b/sample_config/database-layout.sql
@@ -168,11 +168,10 @@ SELECT DISTINCT
     c.end_date,
     c.prio,
     c.shutdown_vm
-FROM
+FROM (
     sysinfo_to_thinclient_mapping s
-    LEFT JOIN (
-        current_thinclient_to_vm_mapping c ON (((s.thinclient)::text = (c.thinclient)::text))
-    )
+    LEFT JOIN current_thinclient_to_vm_mapping c ON (((s.thinclient)::text = (c.thinclient)::text))
+)
 ORDER BY
     c.prio DESC,
     c.start_date,


### PR DESCRIPTION
Commit a1786fa5330fc22c86c378b69b3f046971f5ce87 moved the bracket from the `FROM` to the `LEFT JOIN` which showed an error when importing.

fixes #5 