### PR TITLE
Added functionality for hostnamectl

### DIFF
--- a/virtesk-tc-connectspice/conftest.py
+++ b/virtesk-tc-connectspice/conftest.py
@@ -52,6 +52,14 @@ def nmcli_device_show():
     yield readfile('nmcli_device_show')
 
 
+@pytest.yield_fixture(scope='module')
+def hostnamectl_transient():
+    yield readfile('hostnamectl_transient')
+
+@pytest.yield_fixture(scope='module')
+def hostnamectl_transient_empty():
+    yield readfile('hostnamectl_transient_empty')
+
 def readfile(filename):
     with open(os.path.join(MOCK_DATA_PATH, filename), 'r') as f:
         return f.read()

--- a/virtesk-tc-connectspice/find_thinclient_identifier_nmcli.py
+++ b/virtesk-tc-connectspice/find_thinclient_identifier_nmcli.py
@@ -38,6 +38,11 @@ def extract_identifiers_from_nmcli():
             dhcp_hostname = get_dhcp_hostname_from_connection(value)
             if dhcp_hostname:
                 hostnames.append(dhcp_hostname)
+    hostnamectl_output = subprocess.check_output('hostnamectl', env={'LC_ALL': 'C'})
+    for line in hostnamectl_output.splitlines():
+        if re.match('^Transient', line):
+            key, value = get_line_key_value( line )
+            hostnames.append(value)
     return (hostnames, fixedips)
 
 

--- a/virtesk-tc-connectspice/find_thinclient_identifier_nmcli.py
+++ b/virtesk-tc-connectspice/find_thinclient_identifier_nmcli.py
@@ -38,12 +38,18 @@ def extract_identifiers_from_nmcli():
             dhcp_hostname = get_dhcp_hostname_from_connection(value)
             if dhcp_hostname:
                 hostnames.append(dhcp_hostname)
-    hostnamectl_output = subprocess.check_output('hostnamectl', env={'LC_ALL': 'C'})
+    hostnamectl_hostname = extract_hostname_from_hostnamectl()
+    if hostnamectl_hostname and hostnamectl_hostname not in hostnames:
+        hostnames.append(hostnamectl_hostname)
+    return (hostnames, fixedips)
+
+
+def extract_hostname_from_hostnamectl():
+    hostnamectl_output = subprocess.check_output(['hostnamectl'], env={'LC_ALL': 'C'})
     for line in hostnamectl_output.splitlines():
         if re.match('^Transient', line):
-            key, value = get_line_key_value( line )
-            hostnames.append(value)
-    return (hostnames, fixedips)
+            key, value = get_line_key_value(line)
+            return value
 
 
 def get_dhcp_hostname_from_connection(name):

--- a/virtesk-tc-connectspice/test_find_thinclient_identifier_nmcli.py
+++ b/virtesk-tc-connectspice/test_find_thinclient_identifier_nmcli.py
@@ -1,7 +1,7 @@
 import find_thinclient_identifier_nmcli as find_nmcli
 
 
-def test_extract_identifiers_from_nmcli(mock, nmcli_device_show, nmcli_con_show, nmcli_con_show_empty):
+def test_extract_identifiers_from_nmcli(mock, nmcli_device_show, nmcli_con_show, nmcli_con_show_empty, hostnamectl_transient):
     def my_check_output(cmd, **kwargs):
         if cmd[:4] == ['nmcli', 'con', 'show', 'ADSY-EAP']:
             return nmcli_con_show
@@ -9,10 +9,12 @@ def test_extract_identifiers_from_nmcli(mock, nmcli_device_show, nmcli_con_show,
             return nmcli_con_show_empty
         elif cmd[:3] == ['nmcli', 'device', 'show']:
             return nmcli_device_show
+        elif cmd[:1] == ['hostnamectl']:
+            return hostnamectl_transient
     mock.patch('find_thinclient_identifier_nmcli.subprocess.check_output', my_check_output)
     return_value = find_nmcli.extract_identifiers_from_nmcli()
 
-    assert return_value == (['a-hostname-appeared'], ['172.17.0.1', '10.9.5.185', '127.0.0.1'])
+    assert return_value == (['a-hostname-appeared', 'transient-hostname'], ['172.17.0.1', '10.9.5.185', '127.0.0.1'])
 
 
 def test_get_dhcp_hostname_from_connection(mock, nmcli_con_show):
@@ -46,3 +48,17 @@ def test_get_active_connections(mock, active_connection):
     patched_check_output.return_value = active_connection
     return_value = find_nmcli.get_active_connections()
     assert return_value == 2
+
+
+def test_get_hostname_from_hostnamectl(mock, hostnamectl_transient):
+    patched_check_output = mock.patch('find_thinclient_identifier_nmcli.subprocess.check_output')
+    patched_check_output.return_value = hostnamectl_transient
+    return_value = find_nmcli.extract_hostname_from_hostnamectl()
+    assert return_value == 'transient-hostname'
+
+
+def test_get_hostname_from_hostnamectl_empty(mock, hostnamectl_transient_empty):
+    patched_check_output = mock.patch('find_thinclient_identifier_nmcli.subprocess.check_output')
+    patched_check_output.return_value = hostnamectl_transient_empty
+    return_value = find_nmcli.extract_hostname_from_hostnamectl()
+    assert return_value == None

--- a/virtesk-tc-connectspice/test_mock_data/hostnamectl_transient
+++ b/virtesk-tc-connectspice/test_mock_data/hostnamectl_transient
@@ -1,0 +1,9 @@
+Static hostname: static-hostname
+Transient hostname: transient-hostname
+      Icon name: computer-laptop
+        Chassis: laptop
+     Machine ID: 11111111111111111111111111111111
+        Boot ID: 11111111111111111111111111111111
+Operating System: Ubuntu
+         Kernel: Linux 4.4.0-53-generic
+   Architecture: x86-64

--- a/virtesk-tc-connectspice/test_mock_data/hostnamectl_transient_empty
+++ b/virtesk-tc-connectspice/test_mock_data/hostnamectl_transient_empty
@@ -1,0 +1,8 @@
+Static hostname: static-hostname
+      Icon name: computer-laptop
+        Chassis: laptop
+     Machine ID: 11111111111111111111111111111111
+        Boot ID: 11111111111111111111111111111111
+Operating System: Ubuntu
+         Kernel: Linux 4.4.0-53-generic
+   Architecture: x86-64


### PR DESCRIPTION
Addition to #8: 
On some DHCP server environments, nmcli doesn't get the given hostname even though the name is in the dchlient leasefile.
This change additionally uses hostnamectl to populate the hostnames array.